### PR TITLE
Allow for fmt.Stringer types in string comparisons

### DIFF
--- a/parser/operation.go
+++ b/parser/operation.go
@@ -52,7 +52,7 @@ func newErrInvalidOperand(val Operand, typeObj interface{}) *ErrInvalidOperand {
 }
 
 func (e *ErrInvalidOperand) Error() string {
-	return fmt.Sprintf("Operand %v is not the correc type. Expected: %s, Actual: %s",
+	return fmt.Sprintf("Operand %v is not the correct type. Expected: %s, Actual: %s",
 		e.Val,
 		reflect.TypeOf(e.typeObj).String(),
 		reflect.TypeOf(e.Val).String(),

--- a/parser/string_operation.go
+++ b/parser/string_operation.go
@@ -1,6 +1,7 @@
 package parser
 
 import (
+	"fmt"
 	"strings"
 )
 
@@ -8,17 +9,28 @@ type StringOperation struct {
 	NullOperation
 }
 
+func (o *StringOperation) getString(operand Operand) (string, error) {
+	switch opVal := operand.(type) {
+	case string:
+		return opVal, nil
+	case fmt.Stringer:
+		return opVal.String(), nil
+	default:
+		return "", newErrInvalidOperand(operand, opVal)
+	}
+}
+
 func (o *StringOperation) get(left Operand, right Operand) (string, string, error) {
 	if left == nil {
 		return "", "", ErrEvalOperandMissing
 	}
-	leftVal, ok := left.(string)
-	if !ok {
-		return "", "", newErrInvalidOperand(left, leftVal)
+	leftVal, err := o.getString(left)
+	if err != nil {
+		return "", "", err
 	}
-	rightVal, ok := right.(string)
-	if !ok {
-		return "", "", newErrInvalidOperand(right, rightVal)
+	rightVal, err := o.getString(right)
+	if err != nil {
+		return "", "", err
 	}
 	return strings.ToLower(leftVal), strings.ToLower(rightVal), nil
 

--- a/parser/string_operation.go
+++ b/parser/string_operation.go
@@ -109,9 +109,9 @@ func (o *StringOperation) EW(left Operand, right Operand) (bool, error) {
 }
 
 func (o *StringOperation) IN(left Operand, right Operand) (bool, error) {
-	leftVal, ok := left.(string)
-	if !ok {
-		return false, newErrInvalidOperand(left, leftVal)
+	leftVal, err := o.getString(left)
+	if err != nil {
+		return false, err
 	}
 
 	rightVal, ok := right.([]string)


### PR DESCRIPTION
This will allow for string comparison of any types that implement the String() method.